### PR TITLE
Try making code more idiomatic Rust

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use std::ffi::OsString;
 
 fn main() {
     if let Ok(dir) = get_minecraft_installation_dir() {
-        println!("Minecraft install dir {}", dir.to_str().unwrap());
+        println!("Minecraft install dir {}", dir.display());
         try_minecraft_java(&dir);
     } else {
         println!("Could not find minecraft install dir.");
@@ -93,10 +93,10 @@ fn is_valid_java_installation<P: AsRef<Path>>(path: P) -> bool {
         .status();
 
     if let Ok(status) = status {
-        println!("Found java java installation at: {}", path.to_str().unwrap());
+        println!("Found java java installation at: {}", path.display());
         status.success()
     } else {
-        println!("No valid java installation found at: {}", path.to_str().unwrap());
+        println!("No valid java installation found at: {}", path.display());
         false
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,8 @@ fn main() {
 }
 
 fn try_minecraft_java<P: AsRef<Path>>(dir: P) -> bool {
+    let dir = dir.as_ref();
+
     let paths = [
         "runtime/jre-legacy/windows-x64/jre-legacy/bin/javaw.exe",
         "runtime/jre-legacy/windows-x86/jre-legacy/bin/javaw.exe",
@@ -60,7 +62,9 @@ fn get_minecraft_installation_dir() -> Result<PathBuf> {
 }
 
 fn launch_if_valid_java_installation<P: AsRef<Path>>(path: P) {
-    if !is_valid_java_installation(&path) {
+    let path = path.as_ref();
+
+    if !is_valid_java_installation(path) {
         return;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,13 +20,10 @@ fn main() {
         println!("Could not find minecraft install dir.");
     }
 
-    match env::var_os("JAVA_HOME") {
-        Some(val) => {
-            let mut path = PathBuf::from(val);
-            path.push("bin/javaw.exe");
-            launch_if_valid_java_installation(&path)
-        },
-        None => {},
+    if let Some(val) = env::var_os("JAVA_HOME") {
+        let mut path = PathBuf::from(val);
+        path.push("bin/javaw.exe");
+        launch_if_valid_java_installation(&path)
     }
 
     // Getting thin on the ground, lets check the path.


### PR DESCRIPTION
Changes:

- Use path types (Path, PathBuf) for file/directory paths. `Path` is to `PathBuf` as `str` is to `String`, but the two types have operations specific to file paths on them, for example `join` to join two `Path`s together into a new `PathBuf`, `PathBuf::push` to do the same but mutating the existing `PathBuf`.
- Use generic `AsRef<Path>` parameters for file paths. The `AsRef<T>` trait is implemented for types that can be 1:1 converted into a reference of another type (e.g. `&str` to `&Path`, `PathBuf` to `&Path`, `String` to `&str`) so that you can call the functions that take path arguments using `&str` arguments without having to explicitly convert them to `&Path` slices (e.g. `launch_if_valid_java_installation("javaw");` instead of `launch_if_valid_java_installation(Path::new("javaw"));`).
- Use OsString types where appropriate. Both environment variables and PathBuf are `OsString` internally, the string type for interacting with the OS (which is pretty much a string that does not have to contain valid UTF-8), so converting e.g. env variables to String and then back again to PathBuf is unnecessary checking that the intermediate String is valid UTF-8.
- Instead of `match result { ..., Err(e) => panic!() }`, use `result.unwrap()`/`result.expect()`, it does effectively the same thing and is shorter.
- Use last expression as return value instead of the `return` statement where applicable.
- Generally, paths are specified with forward slashes (even though it won't make a difference here because the code is windows only, but still).

There you go, hope this explanation makes sense! I haven't actually tested this since it obviously doesn't compile on Linux so I had to use the GitHub Actions thing to make sure it even compiles, but there should be no actual difference in functionality :P