### PR TITLE
Pass Mojang Launcher status via command line.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,9 @@ edition = "2018"
 winreg = "0.8"
 native-dialog = "0.5.4"
 webbrowser = "0.5.5"
+windows = "0.9.1"
 
 [build-dependencies]
 embed-resource = "1.6.0"
 winres = "0.1.11"
+windows = "0.9.1"

--- a/build.rs
+++ b/build.rs
@@ -15,5 +15,11 @@ fn main() {
         if let Err(_) = result {
             panic!("Failed to set windows resources");
         }
+
+        windows::build!(
+            Windows::Win32::SystemServices::{CreateMutexA},
+            Windows::Win32::WindowsProgramming::{CloseHandle},
+            Windows::Win32::Debug::{GetLastError, WIN32_ERROR},
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,16 @@
 // See RFC 1665 for additional details
 #![windows_subsystem = "windows"]
 
+mod bindings {
+    windows::include_bindings!();
+}
+
+use bindings::{
+    Windows::Win32::SystemServices::{CreateMutexA},
+    Windows::Win32::WindowsProgramming::{CloseHandle},
+    Windows::Win32::Debug::{GetLastError, WIN32_ERROR},
+};
+
 use winreg::RegKey;
 use std::process::{Command, exit};
 use std::io::Result;
@@ -67,7 +77,11 @@ fn launch_if_valid_java_installation<P: AsRef<Path>>(path: P) {
 
     let launch_exe = env::current_exe().expect("could not get path to current executable");
 
+    let launcher_open = is_mojang_launcher_mutex_open();
+    println!("Mojang Launcher open: {}", launcher_open);
+
     let status = Command::new(path)
+        .arg(format!("-Dfabric.installer.mojanglauncher.open={}", launcher_open))
         .arg("-jar")
         .arg(launch_exe)
         .status();
@@ -116,4 +130,20 @@ fn show_error() -> ! {
 
     // Graceful exit otherwise windows may show additional help
     exit(0)
+}
+
+fn is_mojang_launcher_mutex_open() -> bool {
+    unsafe {
+        let mutex_handle = CreateMutexA(std::ptr::null_mut(), true, "MojangLauncher");
+
+        if GetLastError() == WIN32_ERROR::ERROR_ALREADY_EXISTS {
+            // Already exists so must be already open.
+            return true;
+        }
+
+        // Dont worry its safe ;)
+        CloseHandle(mutex_handle);
+    }
+
+    return false;
 }


### PR DESCRIPTION
This could be used to display a warning to the user to suggest closing the vanilla launcher.
Ideally this would be done as part of the main installer but its a lot more a pita.

Related to the discussion over at: https://github.com/FabricMC/fabric-installer/pull/54