### PR TITLE
Pass run args to JVM

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,7 @@ fn launch_if_valid_java_installation<P: AsRef<Path>>(path: P) {
     let status = Command::new(path)
         .arg("-jar")
         .arg(launch_exe)
+        .args(env::args())// Pass the run args through
         .status();
 
     if let Ok(status) = status {


### PR DESCRIPTION
Needs testing, but seems easy enough.

Fixes https://github.com/FabricMC/fabric-installer/issues/71