### PR TITLE
Set DEPENDENTLOADFLAG linker flag to help prevent against DLL Planting attacks.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,8 +1,8 @@
 # Static link vc runtime this fixes the error about VCRUNTIME140.dll being missing.
 
 [target.x86_64-pc-windows-msvc]
-rustflags = ["-Ctarget-feature=+crt-static"]
+rustflags = ["-Ctarget-feature=+crt-static", "-Clink-arg=/DEPENDENTLOADFLAG:0x800"]
 [target.i686-pc-windows-msvc]
-rustflags = ["-Ctarget-feature=+crt-static"]
+rustflags = ["-Ctarget-feature=+crt-static", "-Clink-arg=/DEPENDENTLOADFLAG:0x800"]
 [target.aarch64-pc-windows-msvc]
-rustflags = ["-Ctarget-feature=+crt-static"]
+rustflags = ["-Ctarget-feature=+crt-static", "-Clink-arg=/DEPENDENTLOADFLAG:0x800"]


### PR DESCRIPTION
This is a precaution and is not in response to any example of this being actively abused, im fairly sure its not something that we could be vulnerable to anyway, but no harm in preventing it. Fabric's installer should not be ran as an admin so there isnt much to gain from getting into our process. At the very least this might prevent some weird crashes. As the fabric installer is almost always ran from the downloads folder I can see some chance of accidentally loading a dll from that dir.

This PR prevents loading of dlls outside of system32 see: https://docs.microsoft.com/en-us/cpp/build/reference/dependentloadflag?view=msvc-160 for more info. 

There are further mesures that could possibly be taken but our 'main' fn in our code is too late as far as I can tell, they would need to be actioned in rust and not here. See https://github.com/rust-lang/rust/issues/56055 and how chrome does this here: https://searchfox.org/mozilla-central/rev/5117a4c4e29fcf80a627fecf899a62f117368abf/security/sandbox/chromium/sandbox/win/src/process_mitigations.cc#46-58
