### PR TITLE
Add logger, improve support for ARM64 & Windows 7

### DIFF
--- a/fabric-installer-native-bootstrap.vcxproj
+++ b/fabric-installer-native-bootstrap.vcxproj
@@ -261,12 +261,14 @@
     </Manifest>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="src\Architecture.cpp" />
     <ClCompile Include="src\Bootstrap.cpp" />
     <ClCompile Include="src\Logger.cpp" />
     <ClCompile Include="src\main.cpp" />
     <ClCompile Include="src\SystemHelper.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="src\Architecture.h" />
     <ClInclude Include="src\Bootstrap.h" />
     <ClInclude Include="src\ISystemHelper.h" />
     <ClInclude Include="resource.h" />

--- a/fabric-installer-native-bootstrap.vcxproj
+++ b/fabric-installer-native-bootstrap.vcxproj
@@ -262,6 +262,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="src\Bootstrap.cpp" />
+    <ClCompile Include="src\Logger.cpp" />
     <ClCompile Include="src\main.cpp" />
     <ClCompile Include="src\SystemHelper.cpp" />
   </ItemGroup>
@@ -269,6 +270,7 @@
     <ClInclude Include="src\Bootstrap.h" />
     <ClInclude Include="src\ISystemHelper.h" />
     <ClInclude Include="resource.h" />
+    <ClInclude Include="src\Logger.h" />
     <ClInclude Include="src\SystemHelper.h" />
   </ItemGroup>
   <ItemGroup>

--- a/fabric-installer-native-bootstrap.vcxproj.filters
+++ b/fabric-installer-native-bootstrap.vcxproj.filters
@@ -24,6 +24,9 @@
     <ClCompile Include="src\SystemHelper.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\Logger.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\Bootstrap.h">
@@ -36,6 +39,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="resource.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\Logger.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/Architecture.cpp
+++ b/src/Architecture.cpp
@@ -1,0 +1,16 @@
+#include "Architecture.h"
+
+std::wstring Architecture::AsString(const Value& arch)
+{
+	switch (arch) {
+	case X64:
+		return L"x64";
+	case ARM64:
+		return L"arm64";
+	case X86:
+		return L"x86";
+	case UNKNOWN:
+	default:
+		return L"unknown";
+	}
+}

--- a/src/Architecture.h
+++ b/src/Architecture.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <string>
+
+namespace Architecture
+{
+	// Ordered to ensure that we only check for JVMs that will run on the host arch.
+	// On an x64 host only check for x64 and x86 as arm will never run.
+	// On x86 there is no need to try any other arch as it wont run.
+	enum Value {
+		UNKNOWN,
+		ARM64,
+		X64,
+		X86,
+	};
+
+	constexpr Value VALUES[] = { UNKNOWN, ARM64, X64, X86 };
+
+	std::wstring AsString(const Value& arch);
+};
+

--- a/src/Bootstrap.cpp
+++ b/src/Bootstrap.cpp
@@ -1,8 +1,6 @@
 #include "Bootstrap.h"
 
-#include <iostream>
 #include <vector>
-#include <map>
 #include <sstream>
 
 namespace {
@@ -146,7 +144,11 @@ const std::vector<std::wstring> Bootstrap::getMinecraftJavaPaths(const HostArchi
 	std::vector<std::wstring> paths;
 
 	for (const HostArchitecture::Value& arch : HostArchitecture::VALUES) {
-		if (arch < hostArch || arch == HostArchitecture::UNKNOWN) {
+		if (arch == HostArchitecture::UNKNOWN) {
+			continue;
+		}
+
+		if (arch < hostArch) {
 			// Skip arches that the host does not support.
 			// E.g: On x64 there is no need to go looking for arm64 JDKs as its never going to run.
 			logger.log(L"Arch not supported: " + HostArchitecture::AsString(arch));

--- a/src/Bootstrap.cpp
+++ b/src/Bootstrap.cpp
@@ -39,8 +39,8 @@ void Bootstrap::launch() {
 }
 
 bool Bootstrap::launchMinecraftLauncher() {
-	const HostArchitecture::Value hostArch = systemHelper.getHostArchitecture();
-	logger.log(L"Host archiecture: " + HostArchitecture::AsString(hostArch));
+	const Architecture::Value hostArch = systemHelper.getHostArchitecture();
+	logger.log(L"Host archiecture: " + Architecture::AsString(hostArch));
 
 	const auto javaPaths = getMinecraftJavaPaths(hostArch);
 
@@ -140,31 +140,31 @@ bool Bootstrap::attemptLaunch(const std::wstring& path, bool checkExists) {
 }
 
 // Return all of the possible java paths, starting with the newest on the host platform, down to the oldest on the none host platforms.
-const std::vector<std::wstring> Bootstrap::getMinecraftJavaPaths(const HostArchitecture::Value& hostArch) {
+const std::vector<std::wstring> Bootstrap::getMinecraftJavaPaths(const Architecture::Value& hostArch) {
 	std::vector<std::wstring> paths;
 
-	for (const HostArchitecture::Value& arch : HostArchitecture::VALUES) {
-		if (arch == HostArchitecture::UNKNOWN) {
+	for (const Architecture::Value& arch : Architecture::VALUES) {
+		if (arch == Architecture::UNKNOWN) {
 			continue;
 		}
 
 		if (arch < hostArch) {
 			// Skip arches that the host does not support.
 			// E.g: On x64 there is no need to go looking for arm64 JDKs as its never going to run.
-			logger.log(L"Arch not supported: " + HostArchitecture::AsString(arch));
+			logger.log(L"Arch not supported: " + Architecture::AsString(arch));
 			continue;
 		}
 
 		std::wstring javaName;
 
 		switch (arch) {
-		case HostArchitecture::X64:
+		case Architecture::X64:
 			javaName = L"windows-x64";
 			break;
-		case HostArchitecture::ARM64:
+		case Architecture::ARM64:
 			javaName = L"windows-arm64";
 			break;
-		case HostArchitecture::X86:
+		case Architecture::X86:
 			javaName = L"windows-x86";
 			break;
 		default:

--- a/src/Bootstrap.h
+++ b/src/Bootstrap.h
@@ -20,7 +20,7 @@ private:
 
 	void showErrorMessage();
 
-	const std::vector<std::wstring> getMinecraftJavaPaths(const HostArchitecture::Value& hostArch);
+	const std::vector<std::wstring> getMinecraftJavaPaths(const Architecture::Value& hostArch);
 
 private:
 	ISystemHelper& systemHelper;

--- a/src/Bootstrap.h
+++ b/src/Bootstrap.h
@@ -3,10 +3,11 @@
 #include <memory>
 
 #include "ISystemHelper.h"
+#include "Logger.h"
 
 class Bootstrap {
 public:
-	explicit Bootstrap(const std::shared_ptr<ISystemHelper>& systemHelper);
+	explicit Bootstrap(ISystemHelper& systemHelper, Logger& logger);
 
 public:
 	void launch();
@@ -19,6 +20,9 @@ private:
 
 	void showErrorMessage();
 
+	const std::vector<std::wstring> getMinecraftJavaPaths(const HostArchitecture::Value& hostArch);
+
 private:
-	std::shared_ptr<ISystemHelper> systemHelper;
+	ISystemHelper& systemHelper;
+	Logger& logger;
 };

--- a/src/ISystemHelper.h
+++ b/src/ISystemHelper.h
@@ -6,6 +6,34 @@
 #include <string>
 #include <vector>
 
+namespace HostArchitecture {
+	// Ordered to ensure that we only check for JVMs that will run on the host arch.
+	// On an x64 host only check for x64 and x86 as arm will never run.
+	// On x86 there is no need to try any other arch as it wont run.
+	enum Value {
+		UNKNOWN,
+		ARM64,
+		X64,
+		X86,
+	};
+
+	constexpr Value VALUES[] = { UNKNOWN, ARM64, X64, X86 };
+
+	inline std::wstring AsString(const Value& arch) {
+		switch (arch) {
+		case X64:
+			return L"x64";
+		case ARM64:
+			return L"arm64";
+		case X86:
+			return L"x86";
+		case UNKNOWN:
+		default:
+			return L"unknown";
+		}
+	}
+}
+
 class ISystemHelper {
 public:
 	virtual std::optional<std::wstring> getRegValue(HKEY hive, const std::wstring& path, const std::wstring& key) = 0;
@@ -15,4 +43,7 @@ public:
 	virtual bool fileExists(const std::wstring& path) = 0;
 	virtual bool dirExists(const std::wstring& path) = 0;
 	virtual std::wstring getBootstrapFilename() = 0;
+	virtual std::wstring getTempDir() = 0;
+	virtual HostArchitecture::Value getHostArchitecture() = 0;
+	virtual long long getEpochTime() = 0;
 };

--- a/src/ISystemHelper.h
+++ b/src/ISystemHelper.h
@@ -6,44 +6,18 @@
 #include <string>
 #include <vector>
 
-namespace HostArchitecture {
-	// Ordered to ensure that we only check for JVMs that will run on the host arch.
-	// On an x64 host only check for x64 and x86 as arm will never run.
-	// On x86 there is no need to try any other arch as it wont run.
-	enum Value {
-		UNKNOWN,
-		ARM64,
-		X64,
-		X86,
-	};
-
-	constexpr Value VALUES[] = { UNKNOWN, ARM64, X64, X86 };
-
-	inline std::wstring AsString(const Value& arch) {
-		switch (arch) {
-		case X64:
-			return L"x64";
-		case ARM64:
-			return L"arm64";
-		case X86:
-			return L"x86";
-		case UNKNOWN:
-		default:
-			return L"unknown";
-		}
-	}
-}
+#include "Architecture.h"
 
 class ISystemHelper {
 public:
-	virtual std::optional<std::wstring> getRegValue(HKEY hive, const std::wstring& path, const std::wstring& key) = 0;
-	virtual std::optional<std::wstring> getEnvVar(const std::wstring& key) = 0;
-	virtual void showErrorMessage(const std::wstring& title, const std::wstring& message, const std::wstring& url) = 0;
-	virtual DWORD createProcess(std::vector<std::wstring> args) = 0;
-	virtual bool fileExists(const std::wstring& path) = 0;
-	virtual bool dirExists(const std::wstring& path) = 0;
-	virtual std::wstring getBootstrapFilename() = 0;
-	virtual std::wstring getTempDir() = 0;
-	virtual HostArchitecture::Value getHostArchitecture() = 0;
-	virtual long long getEpochTime() = 0;
+	virtual std::optional<std::wstring> getRegValue(HKEY hive, const std::wstring& path, const std::wstring& key) const = 0;
+	virtual std::optional<std::wstring> getEnvVar(const std::wstring& key) const = 0;
+	virtual void showErrorMessage(const std::wstring& title, const std::wstring& message, const std::wstring& url) const = 0;
+	virtual DWORD createProcess(std::vector<std::wstring> args) const = 0;
+	virtual bool fileExists(const std::wstring& path) const = 0;
+	virtual bool dirExists(const std::wstring& path) const = 0;
+	virtual std::wstring getBootstrapFilename() const = 0;
+	virtual std::wstring getTempDir() const = 0;
+	virtual Architecture::Value getHostArchitecture() const = 0;
+	virtual int64_t getEpochTime() const = 0;
 };

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -1,0 +1,19 @@
+#include "Logger.h"
+#include <sstream>
+
+namespace {
+    std::wofstream openLogFile(ISystemHelper& systemHelper) {
+		std::wstringstream fileNameBuf;
+		fileNameBuf << systemHelper.getTempDir() << L"/fabric-installer-" << systemHelper.getEpochTime() << L".log";
+        return std::wofstream(fileNameBuf.str());
+	}
+}
+
+Logger::Logger(ISystemHelper& systemHelper) : file_(openLogFile(systemHelper))
+{
+}
+
+Logger::~Logger()
+{
+	file_.close();
+}

--- a/src/Logger.h
+++ b/src/Logger.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "ISystemHelper.h"
+#include <fstream>
+
+class Logger
+{
+public:
+	Logger(ISystemHelper& systemHelper);
+	~Logger();
+
+	template<class T>
+	void log(const T& line) {
+		file_ << line << std::endl;
+	}
+
+private:
+	std::wofstream file_;
+};

--- a/src/SystemHelper.h
+++ b/src/SystemHelper.h
@@ -4,14 +4,14 @@
 
 class SystemHelper : public ISystemHelper {
 public:
-	std::optional<std::wstring> getRegValue(HKEY hive, const std::wstring& path, const std::wstring& key) override;
-	std::optional<std::wstring> getEnvVar(const std::wstring& key) override;
-	void showErrorMessage(const std::wstring& title, const std::wstring& message, const std::wstring& url) override;
-	DWORD createProcess(std::vector<std::wstring> args) override;
-	bool fileExists(const std::wstring& path) override;
-	bool dirExists(const std::wstring& path) override;
-	std::wstring getBootstrapFilename() override;
-	std::wstring getTempDir() override;
-	HostArchitecture::Value getHostArchitecture() override;
-	long long getEpochTime() override;
+	std::optional<std::wstring> getRegValue(HKEY hive, const std::wstring& path, const std::wstring& key) const override;
+	std::optional<std::wstring> getEnvVar(const std::wstring& key) const override;
+	void showErrorMessage(const std::wstring& title, const std::wstring& message, const std::wstring& url) const override;
+	DWORD createProcess(std::vector<std::wstring> args) const override;
+	bool fileExists(const std::wstring& path) const override;
+	bool dirExists(const std::wstring& path) const override;
+	std::wstring getBootstrapFilename() const override;
+	std::wstring getTempDir() const override;
+	Architecture::Value getHostArchitecture() const override;
+	int64_t getEpochTime() const override;
 };

--- a/src/SystemHelper.h
+++ b/src/SystemHelper.h
@@ -11,4 +11,7 @@ public:
 	bool fileExists(const std::wstring& path) override;
 	bool dirExists(const std::wstring& path) override;
 	std::wstring getBootstrapFilename() override;
+	std::wstring getTempDir() override;
+	HostArchitecture::Value getHostArchitecture() override;
+	long long getEpochTime() override;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,6 +39,8 @@ _Use_decl_annotations_ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevI
 	try {
 		bs.launch();
 	} catch (const std::runtime_error& error) {
+		logger.log(L"a runtime error occured:");
+		logger.log(error.what());
 		std::cout << error.what() << std::endl;
 		return 1;
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include "Bootstrap.h"
 #include "SystemHelper.h"
+#include "Logger.h"
 
 #include <stdexcept>
 #include <iostream>
@@ -10,14 +11,30 @@ _Use_decl_annotations_ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevI
 	UNREFERENCED_PARAMETER(pCmdLine);
 	UNREFERENCED_PARAMETER(nCmdShow);
 
-	// We dont want to try and load DLLs from the current directory (Quite often the downloads dir)
-	::SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_SYSTEM32);
+	const auto kernel32Handle = ::GetModuleHandle(TEXT("kernel32.dll"));
+
+	if (kernel32Handle == NULL) {
+		return -1;
+	}
+
+	// Not supported on all versions of Windows 7
+	typedef BOOL(WINAPI* SetDefaultDllDirectoriesFunc)(DWORD);
+	const SetDefaultDllDirectoriesFunc set_default_dll_directries = reinterpret_cast<SetDefaultDllDirectoriesFunc>(::GetProcAddress(kernel32Handle, "SetDefaultDllDirectories"));
+
+	if (set_default_dll_directries) {
+		// We dont want to try and load DLLs from the current directory (Quite often the downloads dir)
+		set_default_dll_directries(LOAD_LIBRARY_SEARCH_SYSTEM32);
+	}
+
 	// https://docs.microsoft.com/en-us/windows/win32/api/heapapi/nf-heapapi-heapsetinformation
 	::HeapSetInformation(::GetProcessHeap(), HeapEnableTerminationOnCorruption, NULL, 0);
 
-	const auto systemHelper = std::make_shared<SystemHelper>();
+	SystemHelper systemHelper;
+	Logger logger { systemHelper };
 
-	auto bs = Bootstrap(systemHelper);
+	logger.log(L"Fabric launcher native bootstrap log:");
+
+	auto bs = Bootstrap(systemHelper, logger);
 
 	try {
 		bs.launch();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,6 @@
 #include "Logger.h"
 
 #include <stdexcept>
-#include <iostream>
 
 _Use_decl_annotations_ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine, int nCmdShow) {
 	UNREFERENCED_PARAMETER(hInstance);
@@ -41,7 +40,6 @@ _Use_decl_annotations_ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevI
 	} catch (const std::runtime_error& error) {
 		logger.log(L"a runtime error occured:");
 		logger.log(error.what());
-		std::cout << error.what() << std::endl;
 		return 1;
 	}
 


### PR DESCRIPTION
- Add a simple log file in %temp%
- Add proper ARM64 support, using the ARM64 JDK provided by the vanilla launcher. Previously it wouldn't use a native Java.
- Fix possible issues where it may try to run an unsupported JDK (e.g an ARM64 JDK on x64, or x64 on x86), in practice I don't think this would have been an issue, but its fixed.
- Fix crash on Windows 7 without the `KB2533623` update.