### PR TITLE
Refresh environment at start

### DIFF
--- a/fabric-installer-native-bootstrap.vcxproj
+++ b/fabric-installer-native-bootstrap.vcxproj
@@ -141,7 +141,7 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalOptions>/DEPENDENTLOADFLAG:0x800 %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalDependencies>Comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Comctl32.lib;userenv.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Manifest>
       <AdditionalManifestFiles>$(ProjectDir)fabric-installer-native-bootstrap.manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
@@ -166,7 +166,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <CETCompat>true</CETCompat>
-      <AdditionalDependencies>Comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Comctl32.lib;userenv.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Manifest>
       <AdditionalManifestFiles>$(ProjectDir)fabric-installer-native-bootstrap.manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
@@ -188,7 +188,7 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalOptions>/DEPENDENTLOADFLAG:0x800 %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalDependencies>Comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Comctl32.lib;userenv.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Manifest>
       <AdditionalManifestFiles>$(ProjectDir)fabric-installer-native-bootstrap.manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
@@ -210,7 +210,7 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalOptions>/DEPENDENTLOADFLAG:0x800 %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalDependencies>Comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Comctl32.lib;userenv.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Manifest>
       <AdditionalManifestFiles>$(ProjectDir)fabric-installer-native-bootstrap.manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
@@ -235,7 +235,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <CETCompat>true</CETCompat>
-      <AdditionalDependencies>Comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Comctl32.lib;userenv.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Manifest>
       <AdditionalManifestFiles>$(ProjectDir)fabric-installer-native-bootstrap.manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
@@ -260,7 +260,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <CETCompat>false</CETCompat>
-      <AdditionalDependencies>Comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Comctl32.lib;userenv.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Manifest>
       <AdditionalManifestFiles>$(ProjectDir)fabric-installer-native-bootstrap.manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>

--- a/src/ISystemHelper.h
+++ b/src/ISystemHelper.h
@@ -19,4 +19,5 @@ public:
 	virtual std::wstring getTempDir() const = 0;
 	virtual Architecture::Value getHostArchitecture() const = 0;
 	virtual int64_t getEpochTime() const = 0;
+	virtual void refreshEnvironment() = 0;
 };

--- a/src/SystemHelper.cpp
+++ b/src/SystemHelper.cpp
@@ -1,8 +1,12 @@
 #include "SystemHelper.h"
 
+#include <chrono>
+#include <memory>
 #include <Shlwapi.h>
 #include <sstream>
-#include <chrono>
+#include <string>
+#include <string_view>
+#include <Userenv.h>
 
 std::optional<std::wstring> SystemHelper::getRegValue(HKEY hive, const std::wstring& path, const std::wstring& key) const {
 	DWORD dataSize{};
@@ -209,4 +213,34 @@ Architecture::Value SystemHelper::getHostArchitecture() const {
 int64_t SystemHelper::getEpochTime() const {
 	const auto now = std::chrono::system_clock::now();
 	return std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch()).count();
+}
+
+void SystemHelper::refreshEnvironment() {
+	HANDLE rawToken = NULL;
+	if (!::OpenProcessToken(::GetCurrentProcess(), TOKEN_QUERY | TOKEN_DUPLICATE, &rawToken)) {
+		throw std::runtime_error("RefreshEnvironment: OpenProcessToken failed");
+	}
+
+	LPVOID rawEnvBlock = nullptr;
+	if (!::CreateEnvironmentBlock(&rawEnvBlock, rawToken, FALSE)) {
+		::CloseHandle(rawToken);
+		throw std::runtime_error("RefreshEnvironment: CreateEnvironmentBlock failed");
+	}
+
+	const wchar_t* pVar = static_cast<const wchar_t*>(rawEnvBlock);
+	while (*pVar != L'\0') {
+		std::wstring_view entry(pVar);
+		const size_t eqPos = entry.find(L'=');
+
+		if (eqPos != std::wstring_view::npos && eqPos > 0) {
+			std::wstring name(entry.substr(0, eqPos));
+			std::wstring value(entry.substr(eqPos + 1));
+			::SetEnvironmentVariableW(name.c_str(), value.c_str());
+		}
+
+		pVar += entry.length() + 1;
+	}
+
+	::DestroyEnvironmentBlock(rawEnvBlock);
+	::CloseHandle(rawToken);
 }

--- a/src/SystemHelper.cpp
+++ b/src/SystemHelper.cpp
@@ -226,6 +226,7 @@ void SystemHelper::refreshEnvironment() {
 		::CloseHandle(rawToken);
 		throw std::runtime_error("RefreshEnvironment: CreateEnvironmentBlock failed");
 	}
+	::SetLastError(0);
 
 	const wchar_t* pVar = static_cast<const wchar_t*>(rawEnvBlock);
 	while (*pVar != L'\0') {

--- a/src/SystemHelper.h
+++ b/src/SystemHelper.h
@@ -13,4 +13,5 @@ public:
 	std::wstring getTempDir() const override;
 	Architecture::Value getHostArchitecture() const override;
 	int64_t getEpochTime() const override;
+	void refreshEnvironment() override;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,7 +2,61 @@
 #include "SystemHelper.h"
 #include "Logger.h"
 
-#include <stdexcept>
+#include <Userenv.h>
+#include <memory>
+#include <string_view>
+#include <string>
+
+#pragma comment(lib, "userenv.lib")
+
+namespace {
+	// RAII deleter for Win32 handles
+	struct HandleDeleter {
+		void operator()(HANDLE h) const {
+			if (h && h != INVALID_HANDLE_VALUE) {
+				::CloseHandle(h);
+			}
+		}
+	};
+
+	// RAII deleter for the Environment Block
+	struct EnvBlockDeleter {
+		void operator()(LPVOID p) const {
+			if (p) {
+				::DestroyEnvironmentBlock(p);
+			}
+		}
+	};
+
+	void RefreshEnvironment() {
+		HANDLE rawToken = NULL;
+		if (!::OpenProcessToken(::GetCurrentProcess(), TOKEN_QUERY | TOKEN_DUPLICATE, &rawToken)) {
+			return;
+		}
+		std::unique_ptr<void, HandleDeleter> hToken(rawToken);
+
+		LPVOID rawEnvBlock = nullptr;
+		// FALSE: build from system/user profile, not inheriting stale process env
+		if (!::CreateEnvironmentBlock(&rawEnvBlock, hToken.get(), FALSE)) {
+			return;
+		}
+		std::unique_ptr<void, EnvBlockDeleter> envBlock(rawEnvBlock);
+
+		const wchar_t* pVar = static_cast<const wchar_t*>(envBlock.get());
+		while (*pVar != L'\0') {
+			std::wstring_view entry(pVar);
+			const size_t eqPos = entry.find(L'=');
+
+			if (eqPos != std::wstring_view::npos && eqPos > 0) {
+				std::wstring name(entry.substr(0, eqPos));
+				std::wstring value(entry.substr(eqPos + 1));
+				::SetEnvironmentVariableW(name.c_str(), value.c_str());
+			}
+
+			pVar += entry.length() + 1;
+		}
+	}
+}
 
 _Use_decl_annotations_ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine, int nCmdShow) {
 	UNREFERENCED_PARAMETER(hInstance);
@@ -27,6 +81,8 @@ _Use_decl_annotations_ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevI
 
 	// https://docs.microsoft.com/en-us/windows/win32/api/heapapi/nf-heapapi-heapsetinformation
 	::HeapSetInformation(::GetProcessHeap(), HeapEnableTerminationOnCorruption, NULL, 0);
+
+	RefreshEnvironment();
 
 	SystemHelper systemHelper;
 	Logger logger { systemHelper };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 #include "SystemHelper.h"
 #include "Logger.h"
 
+#include <stdexcept>
 #include <Userenv.h>
 #include <memory>
 #include <string_view>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,8 +35,7 @@ _Use_decl_annotations_ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevI
 
 	try {
 		systemHelper.refreshEnvironment();
-	}
-	catch (const std::runtime_error& error) {
+	} catch (const std::runtime_error& error) {
 		logger.log(L"refreshEnvironment failed:");
 		logger.log(error.what());
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,61 +3,6 @@
 #include "Logger.h"
 
 #include <stdexcept>
-#include <Userenv.h>
-#include <memory>
-#include <string_view>
-#include <string>
-
-#pragma comment(lib, "userenv.lib")
-
-namespace {
-	// RAII deleter for Win32 handles
-	struct HandleDeleter {
-		void operator()(HANDLE h) const {
-			if (h && h != INVALID_HANDLE_VALUE) {
-				::CloseHandle(h);
-			}
-		}
-	};
-
-	// RAII deleter for the Environment Block
-	struct EnvBlockDeleter {
-		void operator()(LPVOID p) const {
-			if (p) {
-				::DestroyEnvironmentBlock(p);
-			}
-		}
-	};
-
-	void RefreshEnvironment() {
-		HANDLE rawToken = NULL;
-		if (!::OpenProcessToken(::GetCurrentProcess(), TOKEN_QUERY | TOKEN_DUPLICATE, &rawToken)) {
-			return;
-		}
-		std::unique_ptr<void, HandleDeleter> hToken(rawToken);
-
-		LPVOID rawEnvBlock = nullptr;
-		// FALSE: build from system/user profile, not inheriting stale process env
-		if (!::CreateEnvironmentBlock(&rawEnvBlock, hToken.get(), FALSE)) {
-			return;
-		}
-		std::unique_ptr<void, EnvBlockDeleter> envBlock(rawEnvBlock);
-
-		const wchar_t* pVar = static_cast<const wchar_t*>(envBlock.get());
-		while (*pVar != L'\0') {
-			std::wstring_view entry(pVar);
-			const size_t eqPos = entry.find(L'=');
-
-			if (eqPos != std::wstring_view::npos && eqPos > 0) {
-				std::wstring name(entry.substr(0, eqPos));
-				std::wstring value(entry.substr(eqPos + 1));
-				::SetEnvironmentVariableW(name.c_str(), value.c_str());
-			}
-
-			pVar += entry.length() + 1;
-		}
-	}
-}
 
 _Use_decl_annotations_ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine, int nCmdShow) {
 	UNREFERENCED_PARAMETER(hInstance);
@@ -83,12 +28,18 @@ _Use_decl_annotations_ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevI
 	// https://docs.microsoft.com/en-us/windows/win32/api/heapapi/nf-heapapi-heapsetinformation
 	::HeapSetInformation(::GetProcessHeap(), HeapEnableTerminationOnCorruption, NULL, 0);
 
-	RefreshEnvironment();
-
 	SystemHelper systemHelper;
 	Logger logger { systemHelper };
 
 	logger.log(L"Fabric launcher native bootstrap log:");
+
+	try {
+		systemHelper.refreshEnvironment();
+	}
+	catch (const std::runtime_error& error) {
+		logger.log(L"refreshEnvironment failed:");
+		logger.log(error.what());
+	}
 
 	auto bs = Bootstrap(systemHelper, logger);
 


### PR DESCRIPTION
This solves the "The Fabric Installer could not find a valid Java installation." error when running the installer immediately after installing java.

From my limited testing, it works. To reproduce run the java and fabric installer in Windows Sandbox via Powershell. The issue doesn't occur when running the installers from Explorer. It likely also occurs when running the installers from the browser UI. 